### PR TITLE
Switch to Node.js env

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,4 @@
 
 ## Installation
 
-This plugin is written in Typescript, so you need Node.js installed to use it (but you probably have it installed if you want to search npm plugins).
-
-### Install Node.js
-
-To install Node.js, go to https://nodejs.org/ and download the LTS (Long Term Support) version. Alternatively, you can use [nvm](https://github.com/nvm-sh/nvm) (or [nvm-windows](https://github.com/coreybutler/nvm-windows)).
-
-### Install the plugin
-
-You can find this plugin in Flow's Plugin Store, or by running this command in Flow Launcher:
-
-```
-pm install tailwindcss
-```
+Install the plugin from the Plugin Store or via `pm install tailwindcss`. After installation you will be prompted to install/select Node.js if you have not done so.

--- a/plugin.json
+++ b/plugin.json
@@ -5,8 +5,8 @@
   "Description": "Search tailwindcss Docs",
   "Author": "Areeb ur Rub",
   "Version": "1.0.0",
-  "Language": "executable",
+  "Language": "typescript",
   "Website": "https://github.com/areeburrub/tailwindcss-flow-launcher-plugin",
-  "ExecuteFileName": "run.bat",
+  "ExecuteFileName": "build/index.js",
   "IcoPath": "app.png"
 }

--- a/run.bat
+++ b/run.bat
@@ -1,3 +1,0 @@
-@echo off
-SET plugin_dir=%~dp0%
-node "%plugin_dir%/build/index.js" %*


### PR DESCRIPTION
Hi there, this PR will switch the plugin to use Flow's automatic Node.js environment setup. User will be prompted to install/select Node.js, so manual installation will no longer be required.

Tested:
- Installed plugin
- Flow prompts Node.js setup
- Plugin can be used